### PR TITLE
Fix dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,17 @@ For a sample project using this library, check out the [Lightrail Stripe Sample 
 
 ### Composer
 You can add this library as a dependency to your project using `composer`:
-```json
-"require": {
-    "lightrail/lightrail-stripe": "dev-master"
-  }
 ```
+composer require lightrail/lightrail-stripe
+```
+
 Alternatively, you can copy all the files and add `init.php` to your project:
 ```php
 require_once 'lightrail-stripe/init.php';
 
 ```
 ## Requirements ## 
-This library requires `PHP 5.5` or later.
+This library requires `PHP 5.6` or later.
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -49,3 +49,23 @@ The following dependency is also necessary if you want to run the unit tests.
 Copy `~test-config.php` to `test-config.php` and fill in the blank fields. 
 
 Tests can be run from `tests/` with `../vendor/bin/phpunit ./`
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at <https://github.com/Giftbit/lightrail-stripe-php>.
+
+
+## Publishing
+
+After pushing changes to Github, tag a new release. You can do this via the web interface or through the command line:
+
+```
+git tag -a vX.X.X -m "Tag message or title"
+git push origin vX.X.X
+```
+
+Then log into packagist.org and click "Update" on the `lightrail/lightrail` package (you must be logged in as the Lightrail user).
+
+## License
+
+This library is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": ">=5.6",
     "stripe/stripe-php": "^5.3",
     "firebase/php-jwt": "^5.0",
-    "lightrail/lightrail": "^0.3"
+    "lightrail/lightrail": "^0.4"
   },
   "require-dev": {
     "phpunit/phpunit": "5.7.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": ">=5.6",
     "stripe/stripe-php": "^5.3",
     "firebase/php-jwt": "^5.0",
-    "lightrail/lightrail": "^0.2"
+    "lightrail/lightrail": "^0.3"
   },
   "require-dev": {
     "phpunit/phpunit": "5.7.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "authors": [
     {
       "name": "Lightrail Integration Team",
-      "email": "tana.j@lightrail.com"
+      "email": "integrations@lightrail.com"
     }
   ],
   "homepage": "https://lightrail.com/",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "minimum-stability": "dev",
   "require": {
-    "php": ">=5.5",
+    "php": ">=5.6",
     "stripe/stripe-php": "^5.3",
     "firebase/php-jwt": "^5.0",
     "lightrail/lightrail": "^0.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c5db3e0d7d5e62a80e05d385fd124f4",
+    "content-hash": "210f60c523895343278d268b67d05a05",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -54,16 +54,16 @@
         },
         {
             "name": "lightrail/lightrail",
-            "version": "v0.2.0",
+            "version": "v0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Giftbit/lightrail-client-php.git",
-                "reference": "e9aa4e3daf7c5e5ea958f25186401f226293b701"
+                "reference": "438af67af2feae06131510692b6c45577017d32a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Giftbit/lightrail-client-php/zipball/e9aa4e3daf7c5e5ea958f25186401f226293b701",
-                "reference": "e9aa4e3daf7c5e5ea958f25186401f226293b701",
+                "url": "https://api.github.com/repos/Giftbit/lightrail-client-php/zipball/438af67af2feae06131510692b6c45577017d32a",
+                "reference": "438af67af2feae06131510692b6c45577017d32a",
                 "shasum": ""
             },
             "require": {
@@ -88,7 +88,7 @@
             "authors": [
                 {
                     "name": "Lightrail Integration Team",
-                    "email": "tana.j@lightrail.com"
+                    "email": "integrations@lightrail.com"
                 }
             ],
             "description": "Client library for the Lightrail API (www.lightrail.com)",
@@ -98,7 +98,7 @@
                 "lightrail",
                 "payment processing"
             ],
-            "time": "2017-11-25T04:31:53+00:00"
+            "time": "2018-02-16T17:17:40+00:00"
         },
         {
             "name": "stripe/stripe-php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "210f60c523895343278d268b67d05a05",
+    "content-hash": "12cf137b0f879d2b48e3c9381ac4dfa0",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -54,16 +54,16 @@
         },
         {
             "name": "lightrail/lightrail",
-            "version": "v0.3.0",
+            "version": "v0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Giftbit/lightrail-client-php.git",
-                "reference": "438af67af2feae06131510692b6c45577017d32a"
+                "reference": "22046ae928f59f6e4f0fbd987ea97113d2759d71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Giftbit/lightrail-client-php/zipball/438af67af2feae06131510692b6c45577017d32a",
-                "reference": "438af67af2feae06131510692b6c45577017d32a",
+                "url": "https://api.github.com/repos/Giftbit/lightrail-client-php/zipball/22046ae928f59f6e4f0fbd987ea97113d2759d71",
+                "reference": "22046ae928f59f6e4f0fbd987ea97113d2759d71",
                 "shasum": ""
             },
             "require": {
@@ -98,7 +98,7 @@
                 "lightrail",
                 "payment processing"
             ],
-            "time": "2018-02-16T17:17:40+00:00"
+            "time": "2018-03-12T18:36:27+00:00"
         },
         {
             "name": "stripe/stripe-php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4972195368b0b0f62eb9c2c932418844",
+    "content-hash": "9c5db3e0d7d5e62a80e05d385fd124f4",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -58,12 +58,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Giftbit/lightrail-client-php.git",
-                "reference": "71c1a06e9f8b7142b9a928a9618ae9272cec7ff2"
+                "reference": "e9aa4e3daf7c5e5ea958f25186401f226293b701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Giftbit/lightrail-client-php/zipball/71c1a06e9f8b7142b9a928a9618ae9272cec7ff2",
-                "reference": "71c1a06e9f8b7142b9a928a9618ae9272cec7ff2",
+                "url": "https://api.github.com/repos/Giftbit/lightrail-client-php/zipball/e9aa4e3daf7c5e5ea958f25186401f226293b701",
+                "reference": "e9aa4e3daf7c5e5ea958f25186401f226293b701",
                 "shasum": ""
             },
             "require": {
@@ -98,20 +98,20 @@
                 "lightrail",
                 "payment processing"
             ],
-            "time": "2017-11-25T03:39:09+00:00"
+            "time": "2017-11-25T04:31:53+00:00"
         },
         {
             "name": "stripe/stripe-php",
-            "version": "v5.6.0",
+            "version": "v5.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stripe/stripe-php.git",
-                "reference": "0922533c9db11292c7a0aeafc27638f8f31b7fb6"
+                "reference": "026191d12241a76c957884dff75e4f3721b0e77f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/0922533c9db11292c7a0aeafc27638f8f31b7fb6",
-                "reference": "0922533c9db11292c7a0aeafc27638f8f31b7fb6",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/026191d12241a76c957884dff75e4f3721b0e77f",
+                "reference": "026191d12241a76c957884dff75e4f3721b0e77f",
                 "shasum": ""
             },
             "require": {
@@ -153,7 +153,7 @@
                 "payment processing",
                 "stripe"
             ],
-            "time": "2017-10-31T18:52:25+00:00"
+            "time": "2018-02-07T18:36:55+00:00"
         }
     ],
     "packages-dev": [
@@ -213,16 +213,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.x-dev",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "b270f34b740863c588a3f65f5ab7a3afa38a81e5"
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b270f34b740863c588a3f65f5ab7a3afa38a81e5",
-                "reference": "b270f34b740863c588a3f65f5ab7a3afa38a81e5",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
                 "shasum": ""
             },
             "require": {
@@ -254,11 +254,11 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-20T11:34:00+00:00"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "dev-master",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
@@ -408,12 +408,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
                 "shasum": ""
             },
             "require": {
@@ -425,7 +425,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
             },
             "type": "library",
             "extra": {
@@ -463,7 +463,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-11-24T13:59:53+00:00"
+            "time": "2018-02-19T10:16:54+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -534,12 +534,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "8ebba84e5bd74fc5fdeb916b38749016c7232f93"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/8ebba84e5bd74fc5fdeb916b38749016c7232f93",
-                "reference": "8ebba84e5bd74fc5fdeb916b38749016c7232f93",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -573,7 +573,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-24T15:00:59+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -618,16 +618,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "dev-master",
+            "version": "1.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "d107f347d368dd8a384601398280c7c608390ab7"
+                "reference": "9513098641797ce5f459dbc1de5a54c29b0ec1fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/d107f347d368dd8a384601398280c7c608390ab7",
-                "reference": "d107f347d368dd8a384601398280c7c608390ab7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/9513098641797ce5f459dbc1de5a54c29b0ec1fb",
+                "reference": "9513098641797ce5f459dbc1de5a54c29b0ec1fb",
                 "shasum": ""
             },
             "require": {
@@ -663,7 +663,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-03-07T15:42:04+00:00"
+            "time": "2018-01-06T05:27:16+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -671,12 +671,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "958103f327daef5dd0bb328dec53e0a9e43cfaf7"
+                "reference": "58bd196ce8bc49389307b3787934a5117db80fea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/958103f327daef5dd0bb328dec53e0a9e43cfaf7",
-                "reference": "958103f327daef5dd0bb328dec53e0a9e43cfaf7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/58bd196ce8bc49389307b3787934a5117db80fea",
+                "reference": "58bd196ce8bc49389307b3787934a5117db80fea",
                 "shasum": ""
             },
             "require": {
@@ -712,7 +712,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-03-07T08:21:50+00:00"
+            "time": "2017-12-04T15:11:28+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -720,12 +720,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "cb52087e4403c100622f05c8811201cce2607b24"
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/cb52087e4403c100622f05c8811201cce2607b24",
-                "reference": "cb52087e4403c100622f05c8811201cce2607b24",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
                 "shasum": ""
             },
             "require": {
@@ -749,7 +749,7 @@
                 "sebastian/global-state": "^1.1",
                 "sebastian/object-enumerator": "~2.0",
                 "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0.3|~2.0",
+                "sebastian/version": "^1.0.6|^2.0.1",
                 "symfony/yaml": "~2.1|~3.0|~4.0"
             },
             "conflict": {
@@ -794,7 +794,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-11-16T09:54:38+00:00"
+            "time": "2018-02-01T05:50:59+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1327,7 +1327,7 @@
         },
         {
             "name": "sebastian/version",
-            "version": "dev-master",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
@@ -1374,12 +1374,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "935c8b5875fadd80bb2c7c2fcf800bd0192aa3d2"
+                "reference": "66e6e4838054a648b4fc0e376b1a88ffad9f5135"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/935c8b5875fadd80bb2c7c2fcf800bd0192aa3d2",
-                "reference": "935c8b5875fadd80bb2c7c2fcf800bd0192aa3d2",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/66e6e4838054a648b4fc0e376b1a88ffad9f5135",
+                "reference": "66e6e4838054a648b4fc0e376b1a88ffad9f5135",
                 "shasum": ""
             },
             "require": {
@@ -1389,7 +1389,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -1417,7 +1417,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-11-23T22:17:20+00:00"
+            "time": "2018-03-19T04:10:07+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1425,12 +1425,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "14568820af0af65e8ae97c3999b58cc94ea408bf"
+                "reference": "6af42631dcf89e9c616242c900d6c52bd53bd1bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/14568820af0af65e8ae97c3999b58cc94ea408bf",
-                "reference": "14568820af0af65e8ae97c3999b58cc94ea408bf",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/6af42631dcf89e9c616242c900d6c52bd53bd1bb",
+                "reference": "6af42631dcf89e9c616242c900d6c52bd53bd1bb",
                 "shasum": ""
             },
             "require": {
@@ -1475,7 +1475,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-10T19:03:56+00:00"
+            "time": "2018-02-16T09:50:28+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -1483,12 +1483,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "ec37c495d56b68f103acafa95fec5ed39b14d7db"
+                "reference": "90b2f4112475578eb60269266e79514e1b4128b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/ec37c495d56b68f103acafa95fec5ed39b14d7db",
-                "reference": "ec37c495d56b68f103acafa95fec5ed39b14d7db",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/90b2f4112475578eb60269266e79514e1b4128b6",
+                "reference": "90b2f4112475578eb60269266e79514e1b4128b6",
                 "shasum": ""
             },
             "require": {
@@ -1525,7 +1525,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2017-11-24T14:28:50+00:00"
+            "time": "2018-01-28T23:08:18+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1533,12 +1533,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "4a8bf11547e139e77b651365113fc12850c43d9a"
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/4a8bf11547e139e77b651365113fc12850c43d9a",
-                "reference": "4a8bf11547e139e77b651365113fc12850c43d9a",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
                 "shasum": ""
             },
             "require": {
@@ -1575,7 +1575,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:41+00:00"
+            "time": "2018-01-29T19:49:41+00:00"
         }
     ],
     "aliases": [],
@@ -1588,7 +1588,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5"
+        "php": ">=5.6"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
Tracked down and fixed a couple issues from user testing: 
- Bump minimum required PHP version to 5.6: this should have been done at an earlier point, as the existing dependencies don't actually install properly with PHP 5.5
- Bump dependency for vanilla Lightrail client. This fixes an issue where if you run 'composer require lightrail/lightrail-stripe' and then later run 'composer require lightrail/lightrail' the second command would fail. Seems that by default that command refers to the latest version of the package, but because this package ('lightrail-stripe) was previously locked to <v0.2.*, installing the current latest version (v0.3.0) caused a conflict.